### PR TITLE
#18 added compatibility for lower versions than 5.2

### DIFF
--- a/Frontend/WirecardCheckoutPage/Bootstrap.php
+++ b/Frontend/WirecardCheckoutPage/Bootstrap.php
@@ -65,7 +65,7 @@ class Shopware_Plugins_Frontend_WirecardCheckoutPage_Bootstrap extends Shopware_
      */
     public function getVersion()
     {
-        return '1.2.9';
+        return '1.3.0';
     }
 
     /**
@@ -727,23 +727,31 @@ class Shopware_Plugins_Frontend_WirecardCheckoutPage_Bootstrap extends Shopware_
         if (0 == strcmp($payment, 'wcp_invoice') || 0 == strcmp($payment, 'wcp_installment')) {
             // Looking for user data
             $user = Shopware()->Session()->sOrderVariables['sUserData'];
-            if (is_null($user)
-                || !isset($user['additional']['user']['birthday']) // No birthday given
-            ) {
+            if (is_null($user)) {
                 return true;
             }
-            // is birthday a valid date
-            // before: $user['billingaddress']['birthday']
-            $date = explode("-", $user['additional']['user']['birthday']);
+
+            if ($this->assertMinimumVersion('5.2')) {
+                if (!isset($user['additional']['user']['birthday'])) {
+                    return true;
+                }
+                $userDate = $user['additional']['user']['birthday'];
+            } else {
+                if (!isset($user['billingaddress']['birthday'])) {
+                    return true;
+                }
+                $userDate = $user['billingaddress']['birthday'];
+            }
+
+            $date = explode("-", $userDate);
             if (false === checkdate($date[1], $date[2], $date[0])) {
                 return true;
             }
             // Is customer to be of legal age
-            if ((time() - strtotime($user['additional']['user']['birthday'] . ' +18 years')) < 0) {
+            if ((time() - strtotime($userDate . ' +18 years')) < 0) {
                 return true;
             }
         }
-
         return false;
     }
 

--- a/Frontend/WirecardCheckoutPage/Bootstrap.php
+++ b/Frontend/WirecardCheckoutPage/Bootstrap.php
@@ -65,7 +65,7 @@ class Shopware_Plugins_Frontend_WirecardCheckoutPage_Bootstrap extends Shopware_
      */
     public function getVersion()
     {
-        return '1.3.0';
+        return '1.2.10';
     }
 
     /**


### PR DESCRIPTION
- user dob is stored in different tables between these versions but the
  format remains the same so we just check the version and then get the
  dob from there
