### PR TITLE
Fix diplayed width on shopage

### DIFF
--- a/Frontend/WirecardCheckoutPage/Views/responsive/frontend/wirecard_checkout_page/index.tpl
+++ b/Frontend/WirecardCheckoutPage/Views/responsive/frontend/wirecard_checkout_page/index.tpl
@@ -10,7 +10,7 @@
 {block name="frontend_index_content"}
     <div class="content block">
         <div id="payment" class="grid_20">
-            <iframe src="{$redirectUrl}" height="660" id="wcp_iframe" style="border: 0; margin: auto;"></iframe>
+            <iframe src="{$redirectUrl}" height="660" id="wcp_iframe" style="border: 0; margin: auto; width: 100%"></iframe>
         </div>
     </div>
 {/block}


### PR DESCRIPTION
Without a set width the checkout iframe will only fill out a small column on the left of the shopage. Setting width of the iframe to 100% fixes this problem.